### PR TITLE
Log config state of watchIniUpdates and overrideQualityLevels

### DIFF
--- a/src/DllMain.cpp
+++ b/src/DllMain.cpp
@@ -376,9 +376,9 @@ bool DLSS_HookParamFunctions(NVSDK_NGX_Parameter* params)
 
 		spdlog::info("DLSS functions found & parameter hooks applied!");
 		spdlog::info("Settings:");
-		spdlog::info(" - ForceDLAA: {}", forceDLAA ? "true" : "false");
-		spdlog::info(" - OverrideAutoExposure: {}", overrideAutoExposure == 0 ? "default" : (overrideAutoExposure > 0 ? "enable" : "disable"));
-		spdlog::info(" - OverrideAppId: {}", overrideAppId ? "true" : "false");
+		spdlog::info(" - forceDLAA: {}", forceDLAA ? "true" : "false");
+		spdlog::info(" - overrideAutoExposure: {}", overrideAutoExposure == 0 ? "default" : (overrideAutoExposure > 0 ? "enable" : "disable"));
+		spdlog::info(" - overrideAppId: {}", overrideAppId ? "true" : "false");
 
 		// disable NGX param export hooks since they aren't needed now
 

--- a/src/DllMain.cpp
+++ b/src/DllMain.cpp
@@ -379,6 +379,8 @@ bool DLSS_HookParamFunctions(NVSDK_NGX_Parameter* params)
 		spdlog::info(" - forceDLAA: {}", forceDLAA ? "true" : "false");
 		spdlog::info(" - overrideAutoExposure: {}", overrideAutoExposure == 0 ? "default" : (overrideAutoExposure > 0 ? "enable" : "disable"));
 		spdlog::info(" - overrideAppId: {}", overrideAppId ? "true" : "false");
+		spdlog::info(" - watchIniUpdates: {}", watchIniUpdates ? "true" : "false");
+		spdlog::info(" - overrideQualityLevels: {}", overrideQualityLevels ? "true" : "false");
 
 		// disable NGX param export hooks since they aren't needed now
 


### PR DESCRIPTION
Results in logs such as:

> [2023-02-28 17:44:59.414] [info] Settings:
[2023-02-28 17:44:59.414] [info]  - forceDLAA: false
[2023-02-28 17:44:59.414] [info]  - overrideAutoExposure: default
[2023-02-28 17:44:59.414] [info]  - overrideAppId: false
[2023-02-28 17:44:59.414] [info]  - watchIniUpdates: false
[2023-02-28 17:44:59.414] [info]  - overrideQualityLevels: true