### PR TITLE
Add support for force the "IsHDR" flag on

### DIFF
--- a/ConfigTool/Main.cs
+++ b/ConfigTool/Main.cs
@@ -92,7 +92,7 @@ namespace DLSSTweaks.ConfigTool
 
         static string[] BooleanKeys = new[] { "GlobalForceDLAA", "ForceDLAA", "DisableDevWatermark", "VerboseLogging", "Enable", "DisableIniMonitoring", "OverrideAppId", "EnableNvidiaSigOverride", "DynamicResolutionOverride" };
         
-        static string[] OverrideKeys = new[] { "OverrideAutoExposure", "OverrideAlphaUpscaling", "OverrideDlssHud" };
+        static string[] OverrideKeys = new[] { "OverrideAutoExposure", "OverrideAlphaUpscaling", "OverrideDlssHud", "OverrideHDR" };
         static string[] OverrideValues = new[] { "Default", "Force disable", "Force enable" }; // 0, -1, 1
 
         string DlssTweaksDll = "";

--- a/dlsstweaks.ini
+++ b/dlsstweaks.ini
@@ -75,6 +75,15 @@ OverrideSharpening = Default
 ;  (if overlay doesn't seem to draw try setting this to 2 instead to make it use a slightly different method)
 OverrideDlssHud = 0
 
+; OverrideHDR: allows forcing DLSS to run in HDR linear space
+;  This is usually already set up by the game with the correct value:
+;  SDR mode would expect buffers with sRGB encoded colors (values beyond a 0-1 range might or might not be preserved if present),
+;  while HDR mode expects linear sRGB/Rec.709 colors with an unlimited range.
+;  In case a game with DLSS was modded to add HDR support for example, this could help in making DLSS compatible with it,
+;  in case the game run DLSS in SDR mode after post processing.
+;  Set to 0 to leave it at default, 1 to force enable, or -1 to force disable
+OverrideHDR = 0
+
 ; DisableDevWatermark: removes the on-screen watermark shown when using dev DLL
 ;  Can also remove watermark on certain versions of DLSSG/FrameGeneration
 ;  Only useful if you're using a dev version of DLSS, most won't need this

--- a/src/DLSSTweaks.hpp
+++ b/src/DLSSTweaks.hpp
@@ -87,6 +87,7 @@ struct UserSettings
 	bool overrideSharpeningForceDisable = false;
 	bool overrideAppId = false;
 	int overrideDlssHud = 0;
+	int overrideHDR = 0;
 	bool disableDevWatermark = false;
 	bool verboseLogging = false;
 	std::unordered_map<std::string, std::filesystem::path> dllPathOverrides;

--- a/src/UserSettings.cpp
+++ b/src/UserSettings.cpp
@@ -18,6 +18,7 @@ void UserSettings::print_to_log()
 		spdlog::info(" - OverrideSharpening: {}", *overrideSharpening);
 	spdlog::info(" - OverrideAppId: {}", overrideAppId ? "true" : "false");
 	spdlog::info(" - OverrideDlssHud: {}", overrideDlssHud == 0 ? "default" : (overrideDlssHud > 0 ? "enable" : "disable"));
+	spdlog::info(" - OverrideHDR: {}", overrideHDR == 0 ? "default" : (overrideHDR > 0 ? "enable" : "disable"));
 	spdlog::info(" - DisableDevWatermark: {}", disableDevWatermark ? "true" : "false");
 	spdlog::info(" - ResolutionOffset: {}", resolutionOffset);
 	spdlog::info(" - DynamicResolutionOverride: {}", dynamicResolutionOverride ? "true" : "false");
@@ -114,6 +115,7 @@ bool UserSettings::read(const std::filesystem::path& iniPath, int numInisRead)
 	forceDLAA = ini.Get<bool>("DLSS", "ForceDLAA", std::move(forceDLAA));
 	overrideAutoExposure = ini.Get<int>("DLSS", "OverrideAutoExposure", std::move(overrideAutoExposure));
 	overrideAlphaUpscaling = ini.Get<int>("DLSS", "OverrideAlphaUpscaling", std::move(overrideAlphaUpscaling));
+	overrideHDR = ini.Get<int>("DLSS", "OverrideHDR", std::move(overrideHDR));
 
 	std::string sharpeningString = utility::ini_get_string_safe(ini, "DLSS", "OverrideSharpening", std::move(overrideSharpeningString));
 	if (!sharpeningString.length() || !_stricmp(sharpeningString.c_str(), "default") ||

--- a/src/module_hooks/nvngx.cpp
+++ b/src/module_hooks/nvngx.cpp
@@ -223,7 +223,7 @@ void __cdecl NVSDK_NGX_Parameter_SetI(NVSDK_NGX_Parameter* InParameter, const ch
 		dlss.featureCreateFlags = InValue;
 		spdlog::debug("NVSDK_NGX_Parameter_SetI: FeatureCreateFlags = 0x{:X}", dlss.featureCreateFlags);
 		if (dlss.featureCreateFlags & NVSDK_NGX_DLSS_Feature_Flags_IsHDR)
-			spdlog::debug("NVSDK_NGX_Parameter_SetI: - NVSDK_NGX_DLSS_Feature_Flags_IsHDR");
+			spdlog::debug("NVSDK_NGX_Parameter_SetI: - NVSDK_NGX_DLSS_Feature_Flags_IsHDR (use \"OverrideHDR = 1\" to force enable)");
 		if (dlss.featureCreateFlags & NVSDK_NGX_DLSS_Feature_Flags_MVLowRes)
 			spdlog::debug("NVSDK_NGX_Parameter_SetI: - NVSDK_NGX_DLSS_Feature_Flags_MVLowRes");
 		if (dlss.featureCreateFlags & NVSDK_NGX_DLSS_Feature_Flags_MVJittered)
@@ -240,6 +240,20 @@ void __cdecl NVSDK_NGX_Parameter_SetI(NVSDK_NGX_Parameter* InParameter, const ch
 		constexpr int lastKnownFlag = NVSDK_NGX_DLSS_Feature_Flags_AutoExposure;
 		if (auto remainder = dlss.featureCreateFlags & ~((lastKnownFlag << 1) - 1))
 			spdlog::debug("NVSDK_NGX_Parameter_SetI: - unknown flags: 0x{:X}", remainder);
+
+		if (settings.overrideHDR != 0)
+		{
+			if (settings.overrideHDR >= 1) // force HDR
+			{
+				spdlog::debug("OverrideHDR: force enabling flag NVSDK_NGX_DLSS_Feature_Flags_IsHDR");
+				InValue |= NVSDK_NGX_DLSS_Feature_Flags_IsHDR;
+			}
+			else if (settings.overrideHDR < 0) // force disable HDR
+			{
+				spdlog::debug("OverrideHDR: force disabling flag NVSDK_NGX_DLSS_Feature_Flags_IsHDR");
+				InValue = InValue & ~NVSDK_NGX_DLSS_Feature_Flags_IsHDR;
+			}
+		}
 
 		if (settings.overrideAutoExposure != 0)
 		{


### PR DESCRIPTION
to aid with game mods that add HDR support into games (e.g. RenoDX/Luma mods)

It could help with these mods:
https://github.com/clshortfuse/renodx/wiki/Mods